### PR TITLE
Update meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -13,13 +13,12 @@ build:
   script: python -m pip install --no-deps .
 
 channels:
-  - bioconda
   - conda-forge
-  - anaconda
+  - bioconda
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.8
     - pip >=22.1.2
   run:
     - biopython>=1.79


### PR DESCRIPTION
# Description

Set required python version to 3.8.
Removed anaconda channel
Order of channels now is:
1. conda-forge
2. bioconda

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
